### PR TITLE
cmake: add support for DESTDIR when running make install

### DIFF
--- a/cmake/install-script.cmake
+++ b/cmake/install-script.cmake
@@ -5,7 +5,7 @@ file(
 )
 
 get_filename_component(prefix "${CMAKE_INSTALL_PREFIX}" ABSOLUTE)
-set(config_dir "${prefix}/${fccf_INSTALL_CMAKEDIR}")
+set(config_dir "$ENV{DESTDIR}${prefix}/${fccf_INSTALL_CMAKEDIR}")
 set(config_file "${config_dir}/fccfConfig.cmake")
 
 message(STATUS "Installing: ${config_file}")


### PR DESCRIPTION
as title says, without this change it's hard to package this for any distribution

before:
```
$ make install DESTDIR=test
[ 33%] Built target fmt
[ 77%] Built target fccf_lib
[100%] Built target fccf_exe
Install the project...
-- Install configuration: "Debug"
-- Installing: test/usr/local/lib/cmake/argparse/argparseConfig.cmake
-- Installing: test/usr/local/include/argparse/argparse.hpp
-- Installing: test/usr/local/lib/cmake/argparse/argparseConfig-version.cmake
-- Installing: test/usr/local/lib/pkgconfig/argparse.pc
-- Installing: test/usr/local/bin/fccf
-- Installing: test/usr/local/share/fccf/fccfConfigVersion.cmake
-- Installing: /usr/local/share/fccf/fccfConfig.cmake
CMake Error at /home/muttley/git/fccf/cmake/install-script.cmake:12 (file):
  file failed to open for writing (No such file or directory):

    /usr/local/share/fccf/fccfConfig.cmake
Call Stack (most recent call first):
  cmake_install.cmake:78 (include)


make: *** [Makefile:120: install] Error 1
```

after:
```
$ make install DESTDIR=test
[ 33%] Built target fmt
[ 77%] Built target fccf_lib
[100%] Built target fccf_exe
Install the project...
-- Install configuration: "Debug"
-- Installing: test/usr/local/lib/cmake/argparse/argparseConfig.cmake
-- Installing: test/usr/local/include/argparse/argparse.hpp
-- Installing: test/usr/local/lib/cmake/argparse/argparseConfig-version.cmake
-- Installing: test/usr/local/lib/pkgconfig/argparse.pc
-- Installing: test/usr/local/bin/fccf
-- Installing: test/usr/local/share/fccf/fccfConfigVersion.cmake
-- Installing: test/usr/local/share/fccf/fccfConfig.cmake
```
