### PR TITLE
fix builds for android and non-x86_64 architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
     VERSION 0.6.0
     DESCRIPTION "fccf recursively searches a directory to find C/C++ source code matching a search string."
     HOMEPAGE_URL "https://github.com/p-ranav/fccf"
-    LANGUAGES CXX
+    LANGUAGES C CXX
 )
 
 include(cmake/project-is-top-level.cmake)
@@ -20,7 +20,6 @@ endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 
 # ---- Argparse -------------
 
@@ -92,12 +91,14 @@ string(STRIP ${LLVM_CXXFLAGS} LLVM_CXXFLAGS)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LLVM_CXXFLAGS}")
 
 # ---- Threads ------------
-find_package(Threads REQUIRED)
+if(NOT ANDROID)
+  find_package(Threads REQUIRED)
+endif()
 
 ## Append flags to enable exceptions and optimization
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -std=c++17 -fexceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fexceptions")
 
 # ---- Declare library ----
 
@@ -120,7 +121,10 @@ target_compile_features(fccf_lib PUBLIC cxx_std_17)
 target_compile_options (fccf_lib PRIVATE -fexceptions)
 separate_arguments(LLVM_LDFLAGS UNIX_COMMAND "${LLVM_LDFLAGS}")
 target_link_options(fccf_lib PRIVATE ${LLVM_LDFLAGS})
-target_link_libraries(fccf_lib PRIVATE fmt::fmt Threads::Threads)
+target_link_libraries(fccf_lib PRIVATE fmt::fmt)
+if(NOT ANDROID)
+  target_link_libraries(fccf_lib Threads::Threads)
+endif()
 
 # ---- Declare executable ----
 

--- a/source/searcher.hpp
+++ b/source/searcher.hpp
@@ -18,7 +18,9 @@
 #define FMT_HEADER_ONLY 1
 #include <fmt/color.h>
 #include <fmt/core.h>
+#if defined(__x86_64__) || defined (__i686__)
 #include <immintrin.h>
+#endif
 #include <sse2_strstr.hpp>
 #include <thread_pool.hpp>
 

--- a/source/sse2_strstr.cpp
+++ b/source/sse2_strstr.cpp
@@ -2,7 +2,9 @@
 #include <cstring>
 
 #include <ctype.h>
+#if defined(__x86_64__) || defined (__i686__)
 #include <immintrin.h>
+#endif
 #include <sse2_strstr.hpp>
 
 #define FORCE_INLINE inline __attribute__((always_inline))


### PR DESCRIPTION
Android doesn't have a threads library. All 'pthread_*' functions are
implemented in Bionic libc. This is one of the fundamental difference
between Android and Linux distributions and hence CMakeLists.txt was
patched not to look for a threads library on Android.

-march=native flag has been removed in CMakeLists.txt, this flag is
unsupported during cross compilations and also I feel that this flag
should always be passed using CXXFLAGS environment variables to CMake.

Includes for immintrin.h has been disabled for non-x86_64 and non-i686
platforms as this header is only supposed to be used on these platforms.

C language has been passed to project in CMakeLists.txt as it is now
required either for newer CMake versions (2.23+)
