### PR TITLE
avoid target_link_libraries error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,10 +121,11 @@ target_compile_features(fccf_lib PUBLIC cxx_std_17)
 target_compile_options (fccf_lib PRIVATE -fexceptions)
 separate_arguments(LLVM_LDFLAGS UNIX_COMMAND "${LLVM_LDFLAGS}")
 target_link_options(fccf_lib PRIVATE ${LLVM_LDFLAGS})
-target_link_libraries(fccf_lib PRIVATE fmt::fmt)
+set (LIBS fmt::fmt)
 if(NOT ANDROID)
-  target_link_libraries(fccf_lib Threads::Threads)
+  list(APPEND LIBS Threads::Threads)
 endif()
+target_link_libraries(fccf_lib PRIVATE ${LIBS})
 
 # ---- Declare executable ----
 


### PR DESCRIPTION
To avoid issues like:

```
$ cmake -S . -B build -D CMAKE_BUILD_TYPE=Release
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- {fmt} version: 10.2.2
-- Build type: Release
-- Using the single-header code from /home/tw/Dokumente/GitHub/fccf/build/_deps/json-src/single_include/
-- Could NOT find FFI (missing: FFI_LIBRARIES HAVE_FFI_CALL) 
-- Could NOT find LibEdit (missing: LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES) 
-- Could NOT find Terminfo (missing: Terminfo_LIBRARIES Terminfo_LINKABLE) 
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY) (found version "1.2.11")
-- Could NOT find zstd (missing: zstd_LIBRARY zstd_INCLUDE_DIR) 
-- Found LibXml2: /usr/lib/x86_64-linux-gnu/libxml2.so (found version "2.9.13") 
-- Found CURL: /usr/lib/x86_64-linux-gnu/libcurl.so (found version "7.81.0")  
-- Found LLVM 17.0.6
-- Using LLVMConfig.cmake in: /usr/lib/llvm-17/cmake
-- Linker detection: GNU ld
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
CMake Error at CMakeLists.txt:126 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "fccf_lib".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * CMakeLists.txt:124 (target_link_libraries)



-- Configuring incomplete, errors occurred!
```


```
$ cmake --version
cmake version 3.22.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```