### PR TITLE
Update `.clang-tidy` and add `.cache` to `.gitignore`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,15 +1,16 @@
 ---
-# Enable ALL the things! Except not really
 # misc-non-private-member-variables-in-classes: the options don't do anything
-Checks: "*,\
-  -google-readability-todo,\
-  -altera-*,\
-  -fuchsia-*,\
+Checks: "\
+  bugprone-*,\
+  cppcoreguidelines-*,\
+  misc-*,\
+  modernize-*,\
+  performance-*,\
+  portability-*,\
+  readability-*,\
   fuchsia-multiple-inheritance,\
-  -llvm-header-guard,\
-  -llvm-include-order,\
-  -llvmlibc-*,\
-  -misc-non-private-member-variables-in-classes"
+  -misc-non-private-member-variables-in-classes,\
+  -modernize-use-trailing-return-type"
 WarningsAsErrors: ''
 CheckOptions:
   - key: 'bugprone-argument-comment.StrictMode'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cache/
 .idea/
 .vs/
 .vscode/


### PR DESCRIPTION
Only enable certain categories of checks, and disable the `modernize-use-trailing-return-type` check because only a handful of functions use this notation – this can be reenabled if desired!

Also, while we're at it, add `clangd`'s `.cache` folder to the `.gitignore`.