### PR TITLE
Allow users to specify multiple include/exclude globs

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -323,9 +323,9 @@ int main(int argc, char* argv[])
 
   // Configure a searcher
   search::searcher searcher;
-  searcher.m_query = query;
-  searcher.m_filters = filters;
-  searcher.m_excludes = excludes;
+  searcher.m_query = std::move(query);
+  searcher.m_filters = std::move(filters);
+  searcher.m_excludes = std::move(excludes);
   searcher.m_no_ignore_dirs = no_ignore_dirs;
   searcher.m_is_stdout = is_stdout;
   searcher.m_verbose = verbose;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -7,10 +7,9 @@
 #include <vector>
 
 #include <argparse.hpp>
-#include <searcher.hpp>
-#include <unistd.h>
-
 #include <nlohmann/json.hpp>
+#include "searcher.hpp"
+#include <unistd.h>
 
 namespace fs = std::filesystem;
 
@@ -40,8 +39,14 @@ int main(int argc, char* argv[])
       .implicit_value(true);
 
   program.add_argument("-f", "--filter")
-      .help("Only evaluate files that match filter pattern")
-      .default_value(std::string {"*.*"});
+      .help("Only evaluate files that match any of these glob patterns")
+      .default_value<std::vector<std::string>>({"*.*"})
+      .append();
+
+  program.add_argument("-e", "--exclude")
+      .help("Only evaluate files that DO NOT match any of these glob patterns")
+      .default_value<std::vector<std::string>>({})
+      .append();
 
   program.add_argument("--no-ignore-dirs")
       .help(
@@ -239,7 +244,8 @@ int main(int argc, char* argv[])
   auto query = program.get<std::string>("query");
   auto exact_match = program.get<bool>("--exact-match");
 
-  auto filter = program.get<std::string>("-f");
+  auto filters = program.get<std::vector<std::string>>("-f");
+  auto excludes = program.get<std::vector<std::string>>("-e");
   auto no_ignore_dirs = program.get<bool>("--no-ignore-dirs");
 
   auto num_threads = program.get<int>("-j");
@@ -318,7 +324,8 @@ int main(int argc, char* argv[])
   // Configure a searcher
   search::searcher searcher;
   searcher.m_query = query;
-  searcher.m_filter = filter;
+  searcher.m_filters = filters;
+  searcher.m_excludes = excludes;
   searcher.m_no_ignore_dirs = no_ignore_dirs;
   searcher.m_is_stdout = is_stdout;
   searcher.m_verbose = verbose;
@@ -370,10 +377,10 @@ int main(int argc, char* argv[])
   nlohmann::json json_array = nlohmann::json::array();
   if (is_json) {
     searcher.m_custom_printer = [&json_array](std::string_view filename,
-                                             bool is_stdout,
-                                             unsigned start_line,
-                                             unsigned end_line,
-                                             std::string_view code_snippet)
+                                              bool is_stdout,
+                                              unsigned start_line,
+                                              unsigned end_line,
+                                              std::string_view code_snippet)
     {
       nlohmann::json obj;
       obj["filename"] = filename;

--- a/source/searcher.cpp
+++ b/source/searcher.cpp
@@ -1,19 +1,24 @@
 #include <algorithm>
 #include <array>
-#include <fnmatch.h>
-#include <lexer.hpp>
-#include <searcher.hpp>
-namespace fs = std::filesystem;
+#include <filesystem>
+
+#include "searcher.hpp"
 
 #include <clang-c/Index.h>  // This is libclang.
+#include <fnmatch.h>
+
+#include "lexer.hpp"
+
+namespace fs = std::filesystem;
+using namespace std::string_view_literals;
 
 namespace
 {
 void print_code_snippet(std::string_view filename,
-                    bool is_stdout,
-                    unsigned start_line,
-                    unsigned end_line,
-                    std::string_view code_snippet)
+                        bool is_stdout,
+                        unsigned start_line,
+                        unsigned end_line,
+                        std::string_view code_snippet)
 {
   auto out = fmt::memory_buffer();
   if (is_stdout) {
@@ -346,10 +351,10 @@ void searcher::file_search(std::string_view filename, std::string_view haystack)
                                 code_snippet);
                       } else {
                         print_code_snippet(filename,
-                                       m_is_stdout,
-                                       start_line,
-                                       end_line,
-                                       code_snippet);
+                                           m_is_stdout,
+                                           start_line,
+                                           end_line,
+                                           code_snippet);
                       }
 
                       // Line number (start, end)
@@ -419,19 +424,27 @@ bool is_whitelisted(const std::string_view& str)
 void searcher::directory_search(const char* search_path)
 {
   static const bool skip_fnmatch =
-      searcher::m_filter == std::string_view {"*.*"};
+      searcher::m_filters.size() == 1 && searcher::m_filters[0] == "*.*"sv;
 
   for (auto const& dir_entry : fs::recursive_directory_iterator(search_path)) {
     const auto& path = dir_entry.path();
     const char* path_string = path.c_str();
-    if ((searcher::m_no_ignore_dirs || !exclude_directory(path_string)) && fs::is_regular_file(path)) {
-      bool consider_file = false;
-      if ((skip_fnmatch && is_whitelisted(path_string))
+    if ((searcher::m_no_ignore_dirs || !exclude_directory(path_string))
+        && fs::is_regular_file(path))
+    {
+      const auto glob_match = [path_string](const auto glob) -> bool
+      { return fnmatch(glob.data(), path_string, 0) == 0; };
+
+      const bool consider_file = (skip_fnmatch && is_whitelisted(path_string))
           || (!skip_fnmatch
-              && fnmatch(searcher::m_filter.data(), path_string, 0) == 0))
-      {
-        consider_file = true;
-      }
+              && std::any_of(searcher::m_filters.cbegin(),
+                             searcher::m_filters.cend(),
+                             glob_match)
+              && (searcher::m_excludes.empty()
+                  || std::none_of(searcher::m_excludes.cbegin(),
+                                  searcher::m_excludes.cend(),
+                                  glob_match)));
+
       if (consider_file) {
         searcher::m_ts->push_task(
             [pathstring = std::string {path_string}]()

--- a/source/searcher.cpp
+++ b/source/searcher.cpp
@@ -6,6 +6,7 @@
 
 #include <clang-c/Index.h>  // This is libclang.
 #include <fnmatch.h>
+#include <sse2_strstr.hpp>
 
 #include "lexer.hpp"
 

--- a/source/searcher.hpp
+++ b/source/searcher.hpp
@@ -7,7 +7,6 @@
 #define FMT_HEADER_ONLY 1
 #include <fmt/color.h>
 #include <fmt/core.h>
-#include <sse2_strstr.hpp>
 #include <thread_pool.hpp>
 
 namespace search

--- a/source/searcher.hpp
+++ b/source/searcher.hpp
@@ -1,26 +1,12 @@
 #pragma once
-#include <algorithm>
-#include <cassert>
-#include <cctype>
-#include <chrono>
-#include <cstring>
-#include <filesystem>
-#include <fstream>
 #include <functional>
-#include <iostream>
 #include <memory>
-#include <streambuf>
 #include <string>
 #include <string_view>
-#include <thread>
-#include <unordered_set>
 
 #define FMT_HEADER_ONLY 1
 #include <fmt/color.h>
 #include <fmt/core.h>
-#if defined(__x86_64__) || defined (__i686__)
-#include <immintrin.h>
-#endif
 #include <sse2_strstr.hpp>
 #include <thread_pool.hpp>
 
@@ -36,7 +22,8 @@ struct searcher
 {
   static inline std::unique_ptr<thread_pool> m_ts;
   static inline std::string_view m_query;
-  static inline std::string_view m_filter;
+  static inline std::vector<std::string> m_filters;
+  static inline std::vector<std::string> m_excludes;
   static inline bool m_no_ignore_dirs;
   static inline bool m_verbose;
   static inline bool m_is_stdout;


### PR DESCRIPTION
The files searched by fccf will be a union of the set of files selected by each of the filters.

Add an option, `-e` or `--exclude`, to remove paths from the search space.